### PR TITLE
Rewrite README to focus on ONNX and .NET SDK

### DIFF
--- a/NoisePrintSdk.Tests/EstimatorTests.cs
+++ b/NoisePrintSdk.Tests/EstimatorTests.cs
@@ -1,0 +1,29 @@
+using System;
+using System.IO;
+using Xunit;
+
+public class EstimatorTests
+{
+    private static string Map(string relative)
+        => Path.Combine(Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../")), relative);
+
+    [Theory]
+    [InlineData("examples/NC2016_2564.jpeg")]
+    [InlineData("examples/faceswap.jpeg")]
+    public void Jpeg_ReturnsValue(string path)
+    {
+        var est = new JpegQualityEstimator();
+        int? qf = est.EstimateQuality(Map(path));
+        Assert.True(qf.HasValue && qf.Value >= 1 && qf.Value <= 100);
+    }
+
+    [Theory]
+    [InlineData("examples/inpainting.png")]
+    [InlineData("examples/seamcarving.png")]
+    public void Png_ReturnsNull(string path)
+    {
+        var est = new JpegQualityEstimator();
+        int? qf = est.EstimateQuality(Map(path));
+        Assert.Null(qf);
+    }
+}

--- a/NoisePrintSdk.Tests/NoisePrintSdk.Tests.csproj
+++ b/NoisePrintSdk.Tests/NoisePrintSdk.Tests.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\NoisePrintSdk\NoisePrintSdk.csproj" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.7.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.7.0" />
+  </ItemGroup>
+</Project>

--- a/NoisePrintSdk.Tests/RunnerTests.cs
+++ b/NoisePrintSdk.Tests/RunnerTests.cs
@@ -1,0 +1,16 @@
+using System;
+using System.IO;
+using Xunit;
+
+public class RunnerTests
+{
+    [Fact]
+    public void Run_ReturnsOutput()
+    {
+        string img = Path.Combine(Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../")), "examples/faceswap.jpeg");
+        var (qf, shape, time) = OnnxRunner.Run(img);
+        Assert.InRange(qf, 1, 101);
+        Assert.Equal(4, shape.Length);
+        Assert.True(time > 0);
+    }
+}

--- a/NoisePrintSdk/JpegQualityEstimator.cs
+++ b/NoisePrintSdk/JpegQualityEstimator.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using MetadataExtractor;
+using MetadataExtractor.Formats.Jpeg;
+using MetadataExtractor.IO;
+
+/// <summary>
+/// Utility class for estimating the JPEG Quality Factor from quantization tables using MetadataExtractor.
+/// </summary>
+public class JpegQualityEstimator
+{
+    /// <summary>
+    /// Reads the quantization tables of a JPEG image and estimates the Quality Factor (1-100).
+    /// Returns null for non-JPEG files. Note: qf101 is reserved for PNG images.
+    /// </summary>
+    public int? EstimateQuality(string path)
+    {
+        var ext = Path.GetExtension(path).ToLowerInvariant();
+        if (ext != ".jpg" && ext != ".jpeg")
+            return null;
+
+        var segments = JpegSegmentReader.ReadSegments(path, new[] { JpegSegmentType.Dqt });
+        if (segments.Count == 0)
+            return null;
+
+        var values = new List<int>();
+        foreach (var seg in segments)
+        {
+            var reader = new SequentialByteArrayReader(seg.Bytes);
+            while (reader.Available() > 0)
+            {
+                byte pqTq = reader.GetByte();
+                int precision = pqTq >> 4;
+                for (int i = 0; i < 64; i++)
+                {
+                    int val = precision == 0 ? reader.GetByte() : reader.GetUInt16();
+                    values.Add(val);
+                }
+            }
+        }
+
+        if (values.Count < 64)
+            return null;
+
+        int[] baseTable = new int[]
+        {
+            16,11,10,16,24,40,51,61,12,12,14,19,26,58,60,55,
+            14,13,16,24,40,57,69,56,14,17,22,29,51,87,80,62,
+            18,22,37,56,68,109,103,77,24,35,55,64,81,104,113,92,
+            49,64,78,87,103,121,120,101,72,92,95,98,112,100,103,99
+        };
+
+        double scaleSum = 0;
+        for (int i = 0; i < 64; i++)
+            scaleSum += (values[i] * 100.0 - 50.0) / baseTable[i];
+
+        double scale = scaleSum / 64.0;
+        int q = scale <= 100.0 ? (int)Math.Round((200.0 - scale) / 2.0) : (int)Math.Round(5000.0 / scale);
+        return Math.Clamp(q, 1, 100);
+    }
+}

--- a/NoisePrintSdk/NoisePrintSdk.csproj
+++ b/NoisePrintSdk/NoisePrintSdk.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="MetadataExtractor" Version="2.8.1" />
+    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.17.0" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.4" />
+  </ItemGroup>
+</Project>

--- a/NoisePrintSdk/OnnxRunner.cs
+++ b/NoisePrintSdk/OnnxRunner.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.ML.OnnxRuntime;
+using Microsoft.ML.OnnxRuntime.Tensors;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
+
+/// <summary>
+/// Helper for running ONNX Noiseprint models on a single image.
+/// </summary>
+public static class OnnxRunner
+{
+    /// <summary>
+    /// Run the appropriate ONNX model on <paramref name="imagePath"/>.
+    /// </summary>
+    /// <param name="imagePath">Input image.</param>
+    /// <param name="provider">Execution provider name (CPU or CUDA).</param>
+    /// <returns>Tuple with estimated quality factor, output shape and elapsed seconds.</returns>
+    public static (int Qf, int[] Shape, double Time) Run(string imagePath, string provider = "CPU")
+    {
+        var estimator = new JpegQualityEstimator();
+        int? qf = estimator.EstimateQuality(imagePath);
+        if (!qf.HasValue)
+            qf = Path.GetExtension(imagePath).ToLowerInvariant() == ".png" ? 101 : 100;
+
+        string baseDir = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../"));
+        string modelPath = Path.Combine(baseDir, "onnx_models", $"model_qf{qf}.onnx");
+        if (!File.Exists(modelPath))
+            throw new FileNotFoundException(modelPath);
+
+        using Image<L8> img = Image.Load<L8>(imagePath);
+        int w = Math.Min(64, img.Width);
+        int h = Math.Min(64, img.Height);
+        img.Mutate(x => x.Crop(new Rectangle(0, 0, w, h)));
+
+        float[] data = new float[w * h];
+        for (int y = 0; y < h; y++)
+        {
+            for (int x = 0; x < w; x++)
+                data[y * w + x] = img[x, y].PackedValue / 256f;
+        }
+
+        var tensor = new DenseTensor<float>(data, new[] { 1, 1, h, w });
+
+        using var options = CreateOptions(provider);
+        using var session = new InferenceSession(modelPath, options);
+        var inputs = new List<NamedOnnxValue> { NamedOnnxValue.CreateFromTensor("input", tensor) };
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        using IDisposableReadOnlyCollection<DisposableNamedOnnxValue> results = session.Run(inputs);
+        sw.Stop();
+        var output = results.First().AsTensor<float>();
+        return (qf.Value, output.Dimensions.ToArray(), sw.Elapsed.TotalSeconds);
+    }
+
+    private static SessionOptions CreateOptions(string provider)
+    {
+        var opt = new SessionOptions();
+        if (provider.Equals("cuda", StringComparison.OrdinalIgnoreCase))
+            opt.AppendExecutionProvider_CUDA();
+        else
+            opt.AppendExecutionProvider_CPU();
+        return opt;
+    }
+}

--- a/NoisePrintSdk/Program.cs
+++ b/NoisePrintSdk/Program.cs
@@ -1,0 +1,24 @@
+using System;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        if (args.Length == 0)
+        {
+            Console.WriteLine("Usage: NoisePrintSdk <image> [--provider CPU|CUDA]");
+            return;
+        }
+
+        string image = args[0];
+        string provider = "CPU";
+        for (int i = 1; i < args.Length - 1; i++)
+        {
+            if (args[i] == "--provider")
+                provider = args[i + 1];
+        }
+
+        var result = OnnxRunner.Run(image, provider);
+        Console.WriteLine($"QF={result.Qf} shape=({string.Join(',', result.Shape)}) time={result.Time:F3}s");
+    }
+}

--- a/test_onnx.py
+++ b/test_onnx.py
@@ -1,0 +1,51 @@
+import os
+import time
+import numpy as np
+import onnxruntime as ort
+from PIL import Image
+from utilityRead import jpeg_qtableinv
+
+EXAMPLES_DIR = 'examples'
+MODELS_DIR = 'onnx_models'
+
+
+def estimate_qf(path: str) -> int:
+    ext = os.path.splitext(path)[1].lower()
+    if ext == '.png':
+        return 101
+    try:
+        return int(round(jpeg_qtableinv(path)))
+    except Exception:
+        return 100
+
+
+def load_image(path: str):
+    img = Image.open(path).convert('L')
+    img = img.crop((0, 0, min(64, img.width), min(64, img.height)))
+    arr = np.asarray(img, dtype=np.float32) / 256.0
+    return arr[None, None]
+
+
+def run_model(image_path: str):
+    qf = estimate_qf(image_path)
+    model_path = os.path.join(MODELS_DIR, f"model_qf{qf}.onnx")
+    if not os.path.exists(model_path):
+        raise FileNotFoundError(model_path)
+
+    img = load_image(image_path)
+    sess = ort.InferenceSession(model_path, providers=['CPUExecutionProvider'])
+    start = time.perf_counter()
+    result = sess.run(None, {'input': img})[0]
+    elapsed = time.perf_counter() - start
+    return qf, result.shape, elapsed
+
+
+def main():
+    for fname in sorted(os.listdir(EXAMPLES_DIR)):
+        path = os.path.join(EXAMPLES_DIR, fname)
+        qf, shape, secs = run_model(path)
+        print(f"{fname}: QF={qf} output={shape} time={secs:.3f}s")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- rewrite README in English with instructions for the ONNX models and .NET SDK
- document execution of the new `test_onnx.py` script and include sample outputs
- show how to build and run the C# CLI along with average timings

## Testing
- `python test_onnx.py`
- `dotnet build NoisePrintSdk/NoisePrintSdk.csproj -c Release`
- `dotnet test NoisePrintSdk.Tests/NoisePrintSdk.Tests.csproj -c Release`


------
https://chatgpt.com/codex/tasks/task_e_6887234bbf04832580d5191812badcdf