### PR TITLE
Add more .NET SDK tests

### DIFF
--- a/NoisePrintSdk.Tests/EstimatorTests.cs
+++ b/NoisePrintSdk.Tests/EstimatorTests.cs
@@ -26,4 +26,12 @@ public class EstimatorTests
         int? qf = est.EstimateQuality(Map(path));
         Assert.Null(qf);
     }
+
+    [Fact]
+    public void Jpeg_KnownQuality()
+    {
+        var est = new JpegQualityEstimator();
+        int? qf = est.EstimateQuality(Map("examples/faceswap.jpeg"));
+        Assert.Equal(95, qf);
+    }
 }

--- a/NoisePrintSdk.Tests/RunnerTests.cs
+++ b/NoisePrintSdk.Tests/RunnerTests.cs
@@ -13,4 +13,22 @@ public class RunnerTests
         Assert.Equal(4, shape.Length);
         Assert.True(time > 0);
     }
+
+    [Fact]
+    public void Run_JpegKnownQuality()
+    {
+        string img = Path.Combine(Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../")), "examples/faceswap.jpeg");
+        var (qf, shape, _) = OnnxRunner.Run(img);
+        Assert.Equal(95, qf);
+        Assert.Equal(4, shape.Length);
+    }
+
+    [Fact]
+    public void Run_PngReturns101()
+    {
+        string img = Path.Combine(Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../")), "examples/splicing.png");
+        var (qf, shape, _) = OnnxRunner.Run(img);
+        Assert.Equal(101, qf);
+        Assert.Equal(4, shape.Length);
+    }
 }


### PR DESCRIPTION
## Summary
- expand unit tests for the .NET SDK
- check quality factor returned by `JpegQualityEstimator`
- verify `OnnxRunner` output on JPEG and PNG images

## Testing
- `dotnet test NoisePrintSdk.Tests/NoisePrintSdk.Tests.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_688733c7907c83259ec325f9a77efcc6